### PR TITLE
修复无法弹出二维码的问题

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ define Package/luci-app-jd-dailybonus
 	SUBMENU:=3. Applications
 	TITLE:=Luci for JD dailybonus Script 
 	PKGARCH:=all
-	DEPENDS:=+node +wget +wget-ssl +lua +luasocket
+	DEPENDS:=+node +wget +wget-ssl +lua +luasocket +lua-cjson +lua-md5 +luasec
 endef
 
 define Build/Prepare
@@ -44,6 +44,7 @@ define Package/luci-app-jd-dailybonus/install
 	$(INSTALL_DIR) $(1)/usr/share/jd-dailybonus
 	$(INSTALL_BIN) ./root/usr/share/jd-dailybonus/*.sh $(1)/usr/share/jd-dailybonus/
 	$(INSTALL_DATA) ./root/usr/share/jd-dailybonus/*.js $(1)/usr/share/jd-dailybonus/
+	$(INSTALL_DATA) ./root/usr/share/jd-dailybonus/*.lua $(1)/usr/share/jd-dailybonus/
 
 	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d
 	$(INSTALL_DATA) ./root/usr/share/rpcd/acl.d/* $(1)/usr/share/rpcd/acl.d

--- a/luasrc/model/cbi/jd-dailybonus/client.lua
+++ b/luasrc/model/cbi/jd-dailybonus/client.lua
@@ -86,7 +86,7 @@ o.rmempty = true
 o:depends('auto_update', '1')
 
 o = s:option(ListValue, 'remote_url', translate('Source Update Url'))
-o:value('https://cdn.jsdelivr.net/gh/NobyDa/Script/JD-DailyBonus/JD_DailyBonus.js', translate('GitHub'))
+o:value('https://raw.githubusercontent.com/NobyDa/Script/master/JD-DailyBonus/JD_DailyBonus.js', translate('GitHub'))
 o:value('https://gitee.com/jerrykuku/staff/raw/master/JD_DailyBonus.js', translate('Gitee'))
 o.default = 'nil'
 o.rmempty = false

--- a/root/etc/config/jd-dailybonus
+++ b/root/etc/config/jd-dailybonus
@@ -3,7 +3,7 @@ config global
 	option out '0'
 	option stop '100'
 	option serverchan ''
-	option remote_url 'https://cdn.jsdelivr.net/gh/NobyDa/Script/JD-DailyBonus/JD_DailyBonus.js'
+	option remote_url 'https://raw.githubusercontent.com/NobyDa/Script/master/JD-DailyBonus/JD_DailyBonus.js'
 	option serverurl 'scu'
 	option auto_update '1'
 	option auto_update_time '23'


### PR DESCRIPTION
1.添加缺少的依赖：
lua-cjson
lua-md5
luasec

2.添加缺失的文件：
/usr/share/jd-dailybonus/requests.lua
/usr/share/jd-dailybonus/jd_cookie.lua

3.Github源更新脚本使用的jsdeliver cdn存在版本更新不及时的问题，2021.01.20 20:00更新的v1.91，手动检查脚本更新Github和Gitee都还是1.90版本，修改为使用原始GitHub地址无此问题