### PR TITLE
修复1.01 master下无法保存签到问题

### DIFF
--- a/luasrc/controller/jd-dailybonus.lua
+++ b/luasrc/controller/jd-dailybonus.lua
@@ -33,20 +33,25 @@ function run()
 
     data.auto_run = data.auto_run ~= nil and data.auto_run or 0
     data.auto_update = data.auto_update ~= nil and data.auto_update or 0
+    data.cookie = data.cookie ~= nil and data.cookie or 0
+    data.cookie2 = data.cookie2 ~= nil and data.cookie2 or 0
     uci:tset('jd-dailybonus', '@global[0]', data)
     uci:commit('jd-dailybonus')
-    local json_data = {
-        CookieJD = data.cookie,
-        CookieJD2 = data.cookie2:len() == 0 and nil or data.cookie2,
-        JD_DailyBonusDelay = data.stop,
-        JD_DailyBonusTimeOut = data.out
-    }
-    write_json('/root/CookieSet.json', json_data)
-    write_json('/www/CookieSet.json', json_data)
-    luci.sys.call('/usr/share/jd-dailybonus/newapp.sh -r')
-    luci.sys.call('/usr/share/jd-dailybonus/newapp.sh -a')
-    e.error = 0
-
+    if data.cookie ~= "" then
+        local json_data = {
+            CookieJD = data.cookie,
+            CookieJD2 = data.cookie2:len() == 0 and nil or data.cookie2,
+            JD_DailyBonusDelay = data.stop,
+            JD_DailyBonusTimeOut = data.out
+        }
+        write_json('/root/CookieSet.json', json_data)
+        write_json('/www/CookieSet.json', json_data)
+        luci.sys.call('/usr/share/jd-dailybonus/newapp.sh -r')
+        luci.sys.call('/usr/share/jd-dailybonus/newapp.sh -a')
+        e.error = 0
+    else
+        e.error = 1
+    end
     luci.http.prepare_content('application/json')
     luci.http.write_json(e)
 end

--- a/luasrc/view/jd-dailybonus/update_service.htm
+++ b/luasrc/view/jd-dailybonus/update_service.htm
@@ -253,29 +253,38 @@ var jq=$.noConflict();
 	}
 	//保存订阅按钮
 	jq("#update_service").click(function () {
-		let prefix_array = jq(".cbi-input-text").eq(0).attr("id").split(".");
-        prefix_array.pop()
-		var prefix = prefix_array.join(".")+".";
-        let array = jq("form[name*='cbi'").serializeArray()
-        var json = {};
-        jq.each(array, function () {
-            if(this.name.indexOf(prefix) != -1){
-                let aname = this.name.replace(prefix, "");
-                if (json[aname]) {
-                    if (!json[aname].push) {
-                        json[aname] = [json[aname]];
-                    }
-                    json[aname].push(this.value || '');
-                } else {
-                    json[aname] = this.value || '';
-                }
-            }
-        });
-		jq.ajax({
+		prefix_array = $("#cbi-jd-dailybonus-global .cbi-section-node").attr("id").split("-");
+		prefix = prefix_array[prefix_array.length - 1];
+		//console.log(prefix);
+		if ($("[name='cbid.jd-dailybonus." + prefix + ".auto_update']").is(":checked")) {
+			var auto_update = "1";
+		} else {
+			var auto_update = "0";
+		}
+
+		if ($("[name='cbid.jd-dailybonus." + prefix + ".auto_run']").is(":checked")) {
+			var auto_run = "1";
+		} else {
+			var auto_run = "0";
+		}
+		var stop = $("[name='cbid.jd-dailybonus." + prefix + ".stop']").val();
+		var out = $("[name='cbid.jd-dailybonus." + prefix + ".out']").val();
+		var cookie = $("[name='cbid.jd-dailybonus." + prefix + ".cookie']").val();
+		var cookie2 = $("[name='cbid.jd-dailybonus." + prefix + ".cookie2']").val();
+		var data = {
+			auto_update: auto_update,
+			auto_run: auto_run,
+			cookie: cookie,
+			cookie2: cookie2,
+			stop: stop,
+			out: out
+		}
+		//console.log(data);
+		$.ajax({
 			type: "post",
 			url: SAVE_URL,
 			dataType: "json",
-			data: json,
+			data: data,
 			success: function (d) {
 				if (d.error == 0) {
 					update_service();


### PR DESCRIPTION
1、退回部分update_service.htm代码，解决元素捕获问题
2、修改jd-dailybonus.lua，解决单击“保存cookie”后，无法保存cookie，以及cookie1为空时，无报错问题