### PR TITLE
Fix the problem of inconsistent script version after update

### DIFF
--- a/root/lib/upgrade/keep.d/jd-dailybonus
+++ b/root/lib/upgrade/keep.d/jd-dailybonus
@@ -1,1 +1,2 @@
 /usr/share/jd-dailybonus/CookieSet.json
+/usr/share/jd-dailybonus/JD_DailyBonus.js

--- a/root/usr/share/jd-dailybonus/JD_DailyBonus.js
+++ b/root/usr/share/jd-dailybonus/JD_DailyBonus.js
@@ -2,7 +2,7 @@
 
 京东多合一签到脚本
 
-更新时间: 2021.01.20 20:00 v1.91
+更新时间: 2021.01.28 18:40 v1.92
 有效接口: 40+
 脚本兼容: QuantumultX, Surge, Loon, JSBox, Node.js
 电报频道: @NobyDa 
@@ -908,7 +908,7 @@ function JDUserSign1(s, key, title, body) {
 async function JDUserSign2(s, key, title, tid) {
   await new Promise(resolve => {
     $nobyda.get({
-      url: `https://jdjoy.jd.com/api/turncard/channel/detail?turnTableId=${tid}`,
+      url: `https://jdjoy.jd.com/api/turncard/channel/detail?turnTableId=${tid}&invokeKey=yPsq1PHN`,
       headers: {
         Cookie: KEY
       }
@@ -920,7 +920,7 @@ async function JDUserSign2(s, key, title, tid) {
   return new Promise(resolve => {
     setTimeout(() => {
       const JDUrl = {
-        url: 'https://jdjoy.jd.com/api/turncard/channel/sign',
+        url: 'https://jdjoy.jd.com/api/turncard/channel/sign?invokeKey=yPsq1PHN',
         headers: {
           Cookie: KEY
         },


### PR DESCRIPTION
更新后自带的1.91会覆盖最新的1.92，导致更新脚本失效