### PR TITLE
更新二维码互交操作

### DIFF
--- a/luasrc/controller/jd-dailybonus.lua
+++ b/luasrc/controller/jd-dailybonus.lua
@@ -96,7 +96,6 @@ end
 function check_login()
     local uci = luci.model.uci.cursor()
     local data = luci.http.formvalue()
-    local id = data.id
     local post_data = 'lang=chs&appid=300&source=wq_passport&returnurl=https://wqlogin2.jd.com/passport/LoginRedirect?state=1100399130787&returnurl=//home.m.jd.com/myJd/newhome.action?sceneval=2&ufc=&/myJd/home.action'
     local referer='https://plogin.m.jd.com/login/login?appid=300&returnurl=https://wqlogin2.jd.com/passport/LoginRedirect?state='
     local response = luci.sys.exec("echo -n $(wget-ssl --post-data='"..post_data.."' --header='"..Accept.."' --header='"..Accept_Language.."' --header='"..Host.."' --referer='"..referer.."' --user-agent='"..User_Agent.."' --load-cookies="..cookie.." --save-cookies="..cookie.." --keep-session-cookies -q -O - '"..data.check_url.."')")
@@ -107,11 +106,7 @@ function check_login()
     if return_json.error == 0 then
         local pt_key = luci.sys.exec("echo -n $(cat "..cookie.." | grep pt_key | awk '{print $7}')")
         local pt_pin = luci.sys.exec("echo -n $(cat "..cookie.." | grep pt_pin | awk '{print $7}')")
-        local cookieStr = 'pt_key=' .. pt_key .. ';pt_pin=' .. pt_pin .. ';'
-        uci:set('jd-dailybonus', '@global[0]', id, cookieStr)
-        uci:commit('jd-dailybonus')
-        luci.sys.call('lua /usr/share/jd-dailybonus/gen_cookieset.lua')
-        return_json.cookie = cookieStr
+        return_json.cookie = 'pt_key=' .. pt_key .. ';pt_pin=' .. pt_pin .. ';'
     end
 
     luci.http.prepare_content('application/json')

--- a/luasrc/model/cbi/jd-dailybonus/client.lua
+++ b/luasrc/model/cbi/jd-dailybonus/client.lua
@@ -10,7 +10,7 @@ s.anonymous = true
 
 o = s:option(DynamicList, "Cookies", translate("账号 Cookie 列表"))
 o.rmempty = false
-o.description = translate('双击输入框即可调出二维码，扫描后自动填入。')
+o.description = translate('双击输入框或点击添加图标即可调出二维码，扫码后自动填入。')
 
 o = s:option(DummyValue, '', '')
 o.rawhtml = true

--- a/luasrc/view/jd-dailybonus/cookie_tools.htm
+++ b/luasrc/view/jd-dailybonus/cookie_tools.htm
@@ -1,140 +1,165 @@
 <%+cbi/valueheader%>
 <script src="https://cdn.jsdelivr.net/npm/qrcode_js@1.0.0/qrcode.min.js"></script>
 <style>
-    #qrcontainer {
-        position: fixed;
+    #mask-box {
         width: 100%;
         height: 100%;
-        left: 0;
-        top: 0;
-        z-index: 5000;
+        z-index: 1000;
         display: flex;
-        align-items: center;
-        justify-content: center;
-        background: rgba(255, 255, 255, .8);
+        position: absolute;
         text-align: center;
-        transition: all 0.3s;
+        background: rgba(255, 255, 255, .8);
     }
-    #qrcontainer.hidden{
-        opacity: 0;
-        visibility: hidden;
+    #mask-box #code-box {
+        width: 288px;
+        height: 315px;
+        border: 1px solid #585858;
+        padding: 15px;
+        position: absolute;
+        box-shadow: 0px 0px 7px 3px rgb(0 0 0 / 20%);
+        background: #fff url('/luci-static/resources/icons/loading.gif') no-repeat center center;
+        border-radius: 4px;
     }
-
-    #qrcontainer .qframe {
-        background-color: #ffffff;
-        padding: 1rem;
-        border-radius: 0.5rem;
-        border: #6D8A88 1px solid;
-        -webkit-box-shadow: 0px 0px 7px 3px rgba(0, 0, 0, 0.2);
-        box-shadow: 0px 0px 7px 3px rgba(0, 0, 0, 0.2);
+    #mask-box #code-box img {
+        margin-top: 5px;
+    }
+    #mask-box #close-link {
+        float: right;
+        width: 32px;
+        height: 32px;
+        margin: -32px;
+        cursor: pointer;
+        overflow: hidden;
+        background: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48c3ZnIHhtbDpzcGFjZT0icHJlc2VydmUiIHZpZXdCb3g9IjAgMCAxMDAgMTAwIiB5PSIwIiB4PSIwIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSLlnJblsaRfMSIgdmVyc2lvbj0iMS4xIiB3aWR0aD0iNDdweCIgaGVpZ2h0PSI0N3B4IiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgc3R5bGU9IndpZHRoOjEwMCU7aGVpZ2h0OjEwMCU7YmFja2dyb3VuZC1zaXplOmluaXRpYWw7YmFja2dyb3VuZC1yZXBlYXQteTppbml0aWFsO2JhY2tncm91bmQtcmVwZWF0LXg6aW5pdGlhbDtiYWNrZ3JvdW5kLXBvc2l0aW9uLXk6aW5pdGlhbDtiYWNrZ3JvdW5kLXBvc2l0aW9uLXg6aW5pdGlhbDtiYWNrZ3JvdW5kLW9yaWdpbjppbml0aWFsO2JhY2tncm91bmQtY29sb3I6aW5pdGlhbDtiYWNrZ3JvdW5kLWNsaXA6aW5pdGlhbDtiYWNrZ3JvdW5kLWF0dGFjaG1lbnQ6aW5pdGlhbDthbmltYXRpb24tcGxheS1zdGF0ZTpwYXVzZWQiID48ZyBjbGFzcz0ibGRsLXNjYWxlIiBzdHlsZT0idHJhbnNmb3JtLW9yaWdpbjo1MCUgNTAlO3RyYW5zZm9ybTpyb3RhdGUoMGRlZykgc2NhbGUoMC44LCAwLjgpO2FuaW1hdGlvbi1wbGF5LXN0YXRlOnBhdXNlZCIgPjxjaXJjbGUgZmlsbD0iIzMzMyIgcj0iNDAiIGN5PSI1MCIgY3g9IjUwIiBzdHlsZT0iZmlsbDpyZ2IoODksIDg5LCA4OSk7YW5pbWF0aW9uLXBsYXktc3RhdGU6cGF1c2VkIiA+PC9jaXJjbGU+CjxnIHN0eWxlPSJhbmltYXRpb24tcGxheS1zdGF0ZTpwYXVzZWQiID48cGF0aCBkPSJNMjUuMyA0NWg0OS41djEwSDI1LjN6IiBmaWxsPSIjZTE1YjY0IiB0cmFuc2Zvcm09InJvdGF0ZSgtNDQuOTk2IDQ5Ljk5NyA0OS45OTcpIiBzdHlsZT0iZmlsbDpyZ2IoMjU1LCAyNTUsIDI1NSk7YW5pbWF0aW9uLXBsYXktc3RhdGU6cGF1c2VkIiA+PC9wYXRoPjwvZz4KPGcgc3R5bGU9ImFuaW1hdGlvbi1wbGF5LXN0YXRlOnBhdXNlZCIgPjxwYXRoIGQ9Ik00NSAyNS4zaDEwdjQ5LjVINDV6IiBmaWxsPSIjZTE1YjY0IiB0cmFuc2Zvcm09InJvdGF0ZSgtNDUuMDAxIDUwIDUwKSIgc3R5bGU9ImZpbGw6cmdiKDI1NSwgMjU1LCAyNTUpO2FuaW1hdGlvbi1wbGF5LXN0YXRlOnBhdXNlZCIgPjwvcGF0aD48L2c+CjxtZXRhZGF0YSB4bWxuczpkPSJodHRwczovL2xvYWRpbmcuaW8vc3RvY2svIiBzdHlsZT0iYW5pbWF0aW9uLXBsYXktc3RhdGU6cGF1c2VkIiA+PGQ6bmFtZSBzdHlsZT0iYW5pbWF0aW9uLXBsYXktc3RhdGU6cGF1c2VkIiA+Y2xvc2U8L2Q6bmFtZT4KPGQ6dGFncyBzdHlsZT0iYW5pbWF0aW9uLXBsYXktc3RhdGU6cGF1c2VkIiA+Y2xvc2UscmVqZWN0LG9mZixkaXNhYmxlLHJlbW92ZSxkZWxldGUsY2FuY2VsLGRyb3AsY29sbGFwc2U8L2Q6dGFncz4KPGQ6bGljZW5zZSBzdHlsZT0iYW5pbWF0aW9uLXBsYXktc3RhdGU6cGF1c2VkIiA+Ynk8L2Q6bGljZW5zZT4KPGQ6c2x1ZyBzdHlsZT0iYW5pbWF0aW9uLXBsYXktc3RhdGU6cGF1c2VkIiA+bmVmM2Q0PC9kOnNsdWc+PC9tZXRhZGF0YT48L2c+PCEtLSBnZW5lcmF0ZWQgYnkgaHR0cHM6Ly9sb2FkaW5nLmlvLyAtLT48L3N2Zz4=') no-repeat center center;
+    }
+    #mask-box #load-link {
+        color: #fbfbfb;
+        left: 0;
+        right: 0;
+        margin: 0 10px;
+        bottom: 115px;
+        cursor: pointer; 
+        display: block;
+        position: absolute;
+        background: #e4393c;
+        line-height: 48px;
+        text-decoration: none;
+    }
+    div[id$="-html"] {
+        display: none;
+    }
+    div[data-prefix$="Cookies"] {
         position: relative;
     }
-    #qrcontainer .qframe #refresh_qrcode{
-        width: 256px;
-        height: 256px;
-        position: absolute;
-        background-color: rgba(0, 0, 0, 0.5);
-        left: 1rem;
-        top: 1rem;
-        color: #ffffff;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-    }
-    #qrcontainer .qframe #refresh_qrcode.hidden{
-        opacity: 0;
-        visibility: hidden;
-    }
-    #qrcontainer .qframe #refresh_qrcode h3{
-        font-weight: normal;
-    }
-    #qrcontainer .qframe #refresh_qrcode .refresh{
-        display: block;
-        background: #e4393c;
-        width: 80px;
-        height: 30px;
-        margin: 0 auto;
-        line-height: 30px;
-        opacity: 1;
-        z-index: 19;
-        color: #fbfbfb;
-        text-decoration: none;
-        cursor: pointer;
-    }
-    #qrcontainer .qframe .info {
-        padding: 1rem 0 0 0;
-    }
 </style>
-<div id="qrcontainer" class="hidden">
-    <div class="qframe">
-        <div id="refresh_qrcode" class="hidden">
-            <div>
-                <h3>二维码已失效</h3>
-                <div class="refresh" onclick="get_code()">刷新</div>
-            </div>
-        </div>
-        <div id="qrcode"></div>
-        <div class="info">请使用京东手机APP扫码</div>
-    </div>
-</div>
 
 <script type="text/javascript">
-    const QRCODE_URL = '<%=luci.dispatcher.build_url("admin", "services", "jd-dailybonus","qrcode")%>';
-    const CHECK_LOGIN_URL = '<%=luci.dispatcher.build_url("admin", "services", "jd-dailybonus","check_login")%>';
-    let ckid = 0;
-    let config_index = document.querySelector(".cbi-section-node").getAttribute("id").split("-").pop();
-    let ck_input_name ="cbid.jd-dailybonus."+config_index+".Cookies";
-    let ck_input_container = document.getElementById("cbi-jd-dailybonus-"+config_index+"-Cookies");
-    
-    //初始化二维码
-    try {
-        qrcode = new QRCode(document.getElementById("qrcode"),
-                {
-                    text: "sample",
-                    correctLevel: QRCode.CorrectLevel.L
-                });
-        ck_input_container.addEventListener('dblclick', function(e){
-            let el_name = e.target.getAttribute("name");
-            if (el_name == ck_input_name){
-                ckid = e.target.getAttribute("id").split(".").pop();
-                get_code();
-            }
-         });
-    } catch (error) {
-        alert("网络离线状态无法使用二维码获取Cookie，请刷新后重试！")
-    }
+(function( window, document, undefined ) {
+    // 选取 DOM 元素
+    var selector, section = document.querySelector("[data-prefix$='Cookies']");
 
-    //获取二维码
-    function get_code(){
-        XHR.get(QRCODE_URL, null, (x,d) => {
-            document.getElementById("qrcontainer").classList.remove("hidden");
-            document.getElementById("refresh_qrcode").classList.add("hidden");
-            qrcode.clear();
-            qrcode.makeCode(d.qrcode_url);
-            checkLogin(d.check_url);
-        });
+    // 遮罩容器
+    var mask = document.createElement('div');
+    mask.id = 'mask-box';
+
+    // 二维码容器
+    var code = document.createElement('div');
+    code.id = 'code-box';
+    code.innerHTML = "请使用 “手机京东” 进行扫码认证";
+
+    // 刷新按钮
+    var load = document.createElement('a');
+    load.id = 'load-link';
+    load.innerHTML = "刷新";
+
+    // 创建二维码
+    var make = new QRCode( code, { correctLevel: QRCode.CorrectLevel.L });
+
+    // 关闭按钮
+    var link = document.createElement('a');
+    link.id = 'close-link';
+    link.addEventListener('click', ( e ) => {
+        XHR.halt();
+        XHR._q = [];
+        mask.remove();
         return false;
-    }
+    });
 
-    function checkLogin(check_url){
-        let cname = "cookie" + ckid
-        XHR.poll(3, CHECK_LOGIN_URL, { check_url: check_url, id: cname }, (x, d) => {
-            if (d.error == 0) {
-                XHR.halt();
-                XHR._q = [];
-                document.getElementById("qrcontainer").classList.add("hidden");
-                document.getElementById("refresh_qrcode").classList.add("hidden");
-                let prefix_array = document.getElementsByClassName("cbi-input-text")[0].getAttribute("id").split(".")
-                prefix_array.pop()
-                let prefix = prefix_array.join(".")+".";
-                document.getElementById(prefix+ckid).value = d.cookie
-            } else if (d.error == 21 || d.error == 261) {
-                XHR.halt();
-                XHR._q = [];
-                document.getElementById("refresh_qrcode").classList.remove("hidden");
+    // 二维码层居中
+    var center = function() {
+        if ( selector.offsetTop <= 320 ) {
+            code.style.top = selector.offsetTop + selector.offsetHeight + "px";
+        } else {
+            code.style.top = selector.offsetTop - code.offsetHeight + "px";
+        }
+        code.style.left = ( selector.offsetWidth - code.offsetWidth ) / 2 + "px";
+    };
+
+    // 获取二维码
+    var feedback = function() {
+        // 获取通信数据
+        XHR.get( '<%=luci.dispatcher.build_url("admin", "services", "jd-dailybonus","qrcode")%>', null, ( x, d ) => {
+            if ( x.status != 200 ) {
+                alert('获取二维码失败!');
+                return false;
             }
-        });
-    }
+            // 移除刷新
+            load.remove();
+            // 创建二维码
+            make.clear();
+            make.makeCode( d.qrcode_url );
+            // 元素居中
+            center();
 
+            // 监听扫码反馈
+            XHR.poll( 3, '<%=luci.dispatcher.build_url("admin", "services", "jd-dailybonus","check_login")%>', { check_url: d.check_url }, ( x, d ) => {
+                if ( d.error == 0 ) {
+                    // 清除线程
+                    XHR.halt();
+                    XHR._q = [];
+                    // 回写 Cookie 数据
+                    mask.remove();
+                    selector.value = d.cookie;
+                } else if ( d.error == 21 || d.error == 261 ) {
+                    // 清除线程
+                    XHR.halt();
+                    XHR._q = [];
+                    // 插入容器
+                    if ( !document.contains( load ) ) {
+                        // 插入按钮
+                        load.addEventListener('click', feedback );
+                        code.prepend( load );
+                    }
+                }
+            });
+        });
+    };
+
+    // 鼠标事件
+    var event = function( e ) {
+        // 区分单击、双击事件
+        if ( e.target.tagName == "INPUT" && e.type == "dblclick" ) {
+            selector = e.target;
+        } else if ( e.target.tagName == "IMG" && e.type == "click" && /add/ig.test( e.target.src ) ) {
+            selector = section.getElementsByTagName("INPUT");
+            selector = selector.item( selector.length - 1 );
+        } else {
+            return false;
+        }
+        // 插入容器
+        if ( !document.contains( mask ) ) {
+            section.prepend( mask );
+            mask.prepend( code );
+            code.prepend( link );
+            center();
+        }
+        // 获取及监听扫码事件
+        feedback();
+    };
+
+    // 绑定事件
+    section.addEventListener( 'click', event );
+    section.addEventListener( 'dblclick', event );
+})( window, document );
 </script>
 <%+cbi/valuefooter%>

--- a/root/usr/share/jd-dailybonus/gen_cookieset.lua
+++ b/root/usr/share/jd-dailybonus/gen_cookieset.lua
@@ -15,7 +15,7 @@ local data = {
     JD_DailyBonusTimeOut = uci:get('jd-dailybonus', '@global[0]', 'out')
 }
 
-for i, v in pairs( uci:get('jd-dailybonus', '@global[0]', 'Cookies') ) do
+for i, v in pairs( uci:get('jd-dailybonus', '@global[0]', 'Cookies') or {} ) do
     table.insert(data.CookiesJD, {["cookie"]=v})
 end
 


### PR DESCRIPTION
1. 更新页面中二维码的互交操作
2. 移除旧版扫码后会在后台保存 cookie1/2 数据
3. 修复生成 Cookie 配置文件空数据引发的错误

