### PR TITLE
Add support for JD JR Post data body

### DIFF
--- a/luasrc/model/cbi/jd-dailybonus/client.lua
+++ b/luasrc/model/cbi/jd-dailybonus/client.lua
@@ -16,6 +16,11 @@ o = s:option(DummyValue, '', '')
 o.rawhtml = true
 o.template = 'jd-dailybonus/cookie_tools'
 
+o = s:option(DynamicList, "jrBody", translate('金融 POST Body'))
+o.rmempty = false
+o.default = ''
+o.description = translate('京东金融签到 POST Body（以reqData=开头），与上方的Cookies列表一一对应，没有可不填（可能导致京东金融签到失败）')
+
 o = s:option(Value, 'stop', translate('延迟签到'))
 o.rmempty = false
 o.default = 0

--- a/root/usr/share/jd-dailybonus/gen_cookieset.lua
+++ b/root/usr/share/jd-dailybonus/gen_cookieset.lua
@@ -19,6 +19,10 @@ for i, v in pairs( uci:get('jd-dailybonus', '@global[0]', 'Cookies') or {} ) do
     table.insert(data.CookiesJD, {["cookie"]=v})
 end
 
+for i, v in pairs( uci:get('jd-dailybonus', '@global[0]', 'jrBody') or {} ) do
+    data.CookiesJD[i]["jrBody"]=v
+end
+
 data.CookiesJD = json.stringify( data.CookiesJD )
 
 write_json('/usr/share/jd-dailybonus/CookieSet.json', data)


### PR DESCRIPTION
This commit allows users to store their post body for JD JR site, which actually enables daily check-in for JD JR, and double check-in for JD & JD JR