### PR TITLE
修正京东签到钉钉通知失败，优化通知显示

### DIFF
--- a/root/usr/share/jd-dailybonus/newapp.sh
+++ b/root/usr/share/jd-dailybonus/newapp.sh
@@ -20,7 +20,7 @@ usage() {
 		Valid options are:
 
 		    -a                      Add Cron
-		    -n                      Check 
+		    -n                      Check
 		    -r                      Run Script
 		    -u                      Update Script From Server
 		    -s                      Save Cookie And Add Cron
@@ -77,13 +77,13 @@ notify() {
         fi
         uclient-fetch -q --post-data="text=$title~&desp=$desc" $serverurl$sckey.send
     fi
-    
+
     #Dingding
     dtoken=$(uci_get_by_type global dd_token)
     if [ ! -z $dtoken ]; then
-    	DTJ_FILE=/tmp/jd-djson.json
-	echo "{\"msgtype\": \"markdown\",\"markdown\": {\"title\":\"${title}\",\"text\":\"${title} <br/> ${desc}\"}}" > ${DTJ_FILE}
-    	uclient-fetch -q --post-file=/tmp/jd-djson.json "https://oapi.dingtalk.com/robot/send?access_token=${dtoken}"
+        DTJ_FILE=/tmp/jd-djson.json
+        echo -e "{\"msgtype\": \"markdown\",\"markdown\": {\"title\":\"${title}\",\"text\":\"${title}\n\n${desc}\"}}" > ${DTJ_FILE}
+        wget -q --output-document=/dev/null --header="Content-Type: application/json" --post-file=${DTJ_FILE} "https://oapi.dingtalk.com/robot/send?access_token=${dtoken}"
     fi
 
     #telegram
@@ -92,7 +92,7 @@ notify() {
     API_URL="https://api.telegram.org/bot${TG_BOT_TOKEN}/sendMessage"
     if [ ! -z $TG_BOT_TOKEN ] && [ ! -z $TG_USER_ID ]; then
         text="*$title*
-        
+
 \`\`\`
 "$desc"
 ===============================


### PR DESCRIPTION
修正京东签到插件更换uclient-fetch 后钉钉通知失效，同时优化钉钉通知回车换行。
Fix #190 #201 